### PR TITLE
Enhanced SAT>IP support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,3 +32,7 @@ Fab Stz <fabstz-it@yahoo.fr>
 
 Manuel Reimer
  - for pointing to FTBC on wirbelscan plugin (missing <cstdint> in countries.h)
+
+Lars Theorin
+ - for fixing --satip-server usage
+ - for adding --satip-force-tcp to enable TCP-over-RTSP transport

--- a/CmdOpts.cpp
+++ b/CmdOpts.cpp
@@ -126,6 +126,7 @@ bool ParseArguments(int argc, char* argv[]) {
   std::string Source("S19.2E");
   int RotorPosition = 9999;
   bool use_satip = false;
+  bool tcp_satip = false;
 
   size_t p = ProgName.find_last_of("/\\");
   if (p != std::string::npos)
@@ -168,6 +169,8 @@ bool ParseArguments(int argc, char* argv[]) {
         return ExtHelpText(ProgName);
      else if ((Argument == "-t") or (Argument == "--satip"))
         use_satip = true;
+     else if (Argument == "--satip-force-tcp")
+        tcp_satip = true;
      else if ((Argument == "-f") or (Argument == "--frontend")) {
         PARAM("a,c,s,t");
         if      (Param == "a") WirbelscanSetup.DVB_Type = 5;
@@ -379,14 +382,17 @@ bool ParseArguments(int argc, char* argv[]) {
      }
 
   if (use_satip) {
-     std::string options("-t 16384 ");
+     std::string options(WirbelscanSetup.verbosity > 5 ? "-t 16385;" : "-t 16384;");
 
      // add further satip plugin options as needed.
      if (not WirbelscanSetup.SatipSvr.empty())
-        options += "-s" + WirbelscanSetup.SatipSvr;
+        options += "-s " + WirbelscanSetup.SatipSvr;
 
      libs.push_back(new Library(LibSatip, options));
      satip = libs[1]->Plugin();
+     if (satip && tcp_satip) {
+       satip->SetupParse("TransportMode","2");
+       }
      }
 
   switch(WirbelscanSetup.DVB_Type) {
@@ -510,6 +516,8 @@ bool ExtHelpText(std::string ProgName) {
   ss << "                 192.168.2.66|DVBS2-4|OctopusNet;192.168.0.2|DVBT2-4|minisatip:0x18" << std::endl;
   ss << "                 192.168.2.66:554|DVBS2-2:S19.2E|OctopusNet;192.168.2.2:8554|DVBS2-4:S19.2E,S1W|minisatip" << std::endl;
   ss << "               for detailed description, refer to vdr-plugin-satip's README." << std::endl;
+  ss << "       --satip-force-tcp" << std::endl;
+  ss << "               force the use of TCP-over-RTSP for transport." << std::endl;
   ss << ".................DVB-C..................." << std::endl;
   ss << "       -i N, --inversion N" << std::endl;
   ss << "               spectral inversion setting for cable TV" << std::endl;

--- a/README
+++ b/README
@@ -200,6 +200,10 @@ and the complete help with DiSEqC switches or rotors, SCR, (..) with
 - now also using SAT>IP, instead of local DVB hardware
      w_scan_cpp -fs -sS19E2 -x --satip
 
+- and now also using one specific remote SAT>IP server in a differnt LAN
+     w_scan_cpp -fs -sS19E2 -x --satip --satip-force-tcp \
+                --satip-server '192.168.88.22:554|DVBS2-1|forced:0x08'
+
 - DVB-S/S2 with VLC player config
      w_scan_cpp -fs -sS19E2 -L
 


### PR DESCRIPTION
This patch adds:
- A new option '--satip-force-tcp' to enable the TCP-over-RTSP for the SAT>IP protocol.
- Futhermore it fixes a bug when using the '--satip-server' parameter (until now not used at all).
- Finally it activates more debug of the satip plugin with a level 6 of verbosity.

Without this patch the parameter '--satip-server' doesn't work because the split character requires to be ';' to initialize the plugins (and not the space). Therefore until now only the debug level is pased to the satip plugin, making the parameter useless.

Additionally, with the changes added it will be possible to use the tool with a SAT>IP server not in the same network. Declaring the server manually and enabling the TCP transport, you can reach a remote server through a NAT router. Example:

`w_scan_cpp -fs -sS19E2 --satip --satip-force-tcp --satip-server '192.168.88.22:554|DVBS2-1|forced:0x08'`

Using this line you can use the server 192.168.88.22 in another network. Take note that this SAT>IP server requires to support the TCP-over-RTSP mode. And don't miss to use the quotes because the three sections are required and the '|' is not passed without them.


