### PR TITLE
Update OutputFormats.cpp

### DIFF
--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -1597,7 +1597,6 @@ void PrintXML(std::vector<TChannel>& List) {
   for(auto c:List) {
      if (c.Name.empty()) c.Name = "empty";
 
-     indent++;
      ss << INDENT << "<service"
         << " ONID=" << '"' << c.ONID << '"'
         << " TSID=" << '"' << c.TID  << '"'


### PR DESCRIPTION
Fix identation of the XML output.

Some lines afterward (ine the line: `<< ">" << std::endl;  indent++;`) another increment of the identation is done. This patch fixes the incorrect output of the XML output in the services section. 