### PR TITLE
Implementation of Fake unused functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ WIRBELSCAN_VERSION = wirbelscan-2023.06.04
 SATIP_GIT_ADDR = https://github.com/wirbel-at-vdr-portal/vdr-plugin-satip.git
 
 
+#/******************************************************************************
+# * COMPACT_STATIC = 0 : the regular binary is generated with all shared libs
+# * COMPACT_STATIC = 1 : the binary doesn't link to unnecessary libraries
+# *****************************************************************************/
+COMPACT_STATIC = 1
 
 #/******************************************************************************
 # * if you are still running a distro, not beeing able to use all valid
@@ -198,7 +203,10 @@ APIVERSION   = $(shell sed -ne '/define APIVERSION/s/^.*"\(.*\)".*$$/\1/p' $(vdr
 DEFINES   = -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DPLUGIN_NAME_I18N='"cmd"'
 DEFINES  += -DAPIVERSION='"$(APIVERSION)"'
 DEFINES  += -DSTATIC_PLUGINS
-LIBS      = -ljpeg -pthread -lcap -ldl -lrt $(shell $(PKG_CONFIG) --libs freetype2 fontconfig)
+LIBS      = -pthread -lcap -ldl
+ifeq ($(COMPACT_STATIC),0)
+  LIBS   += -ljpeg $(shell $(PKG_CONFIG) --libs freetype2 fontconfig)
+endif
 LIBS     += $(shell curl-config --libs)
 LIBS     += $(shell $(PKG_CONFIG) --libs-only-l $(LIBPUGIXML))
 LIBS     += $(shell $(PKG_CONFIG) --libs-only-l $(LIBREPFUNC))
@@ -217,6 +225,9 @@ LDFLAGS  += $(shell $(PKG_CONFIG) --libs-only-L $(LIBREPFUNC))
 
 
 SOURCES           := $(sort $(wildcard $(srcdir)/*.cpp))
+ifeq ($(COMPACT_STATIC),1)
+  SOURCES         += $(sort $(wildcard $(srcdir)/micro/*.cpp))
+endif
 VDR_SOURCES       := $(shell find $(vdrdir)  -maxdepth 1 ! -name "vdr.c" -name "*.c" 2>/dev/null | LC_ALL=C sort)
 LIBSI_SOURCES     := $(sort $(wildcard $(vdrlibsidir)/*.c))
 WIRBELSCAN_SOURCES = $(sort $(wildcard $(pluginsrcdir)/wirbelscan/*.cpp))

--- a/micro/fake-layer.cpp
+++ b/micro/fake-layer.cpp
@@ -1,0 +1,190 @@
+/*
+  Pure FAKE functions for linking (at compile time) "w_scan_cpp"
+  without these libraries:
+
+    - fontconfig
+    - freetype2
+    - jpeg
+    
+  This works because this tool is command line only, and it uses
+  VDR and third party plugins. However, the graphical part is not
+  used at all. Therefore, we can overcome entirelly this code.
+  With a regular compilation the calls to these libraries exist,
+  but in fact they never be called. So we can provide a fake
+  implementation to link without these libraries.
+  
+  Note: You need the original headers to complete the compilation.
+*/
+
+#include <fontconfig/fontconfig.h>
+
+#include <ft2build.h>
+#include <freetype/freetype.h>
+
+#include <jpeglib.h>
+
+/* ************************************************************************ */
+/* fontconfig.h */
+
+FcPublic FcBool
+FcInit (void)
+{return 1;}
+
+FcPublic FcObjectSet *
+FcObjectSetBuild (const char *first, ...)
+{return 0;}
+
+FcPublic FcPattern *
+FcPatternCreate (void)
+{return 0;}
+
+FcPublic FcFontSet *
+FcFontList (FcConfig	*config,
+	    FcPattern	*p,
+	    FcObjectSet *os)
+{return 0;}
+
+FcPublic FcBool
+FcPatternAddBool (FcPattern *p, const char *object, FcBool b)
+{return 1;}
+
+FcPublic FcChar8 *
+FcNameUnparse (FcPattern *pat)
+{return 0;}
+
+FcPublic void
+FcFontSetDestroy (FcFontSet *s)
+{return ;}
+
+FcPublic void
+FcPatternDestroy (FcPattern *p)
+{return ;}
+
+FcPublic void
+FcObjectSetDestroy (FcObjectSet *os)
+{return ;}
+
+FcPublic FcBool
+FcPatternAddInteger (FcPattern *p, const char *object, int i)
+{return 1;}
+
+FcPublic FcBool
+FcConfigSubstitute (FcConfig	*config,
+		    FcPattern	*p,
+		    FcMatchKind	kind)
+{return 1;}
+
+FcPublic void
+FcDefaultSubstitute (FcPattern *pattern)
+{return ;}
+
+FcPublic FcFontSet *
+FcFontSort (FcConfig	 *config,
+	    FcPattern    *p,
+	    FcBool	 trim,
+	    FcCharSet    **csp,
+	    FcResult	 *result)
+{return 0;}
+
+FcPublic FcResult
+FcPatternGetBool (const FcPattern *p, const char *object, int n, FcBool *b)
+{return (FcResult)0;}
+
+FcPublic FcResult
+FcPatternGetString (const FcPattern *p, const char *object, int n, FcChar8 ** s)
+{return (FcResult)0;}
+
+FcPublic FcPattern *
+FcNameParse (const FcChar8 *name)
+{return 0;}
+
+
+/* ************************************************************************ */
+/* ft2build.h */
+
+  FT_EXPORT( FT_UInt )
+  FT_Get_Char_Index( FT_Face   face,
+                     FT_ULong  charcode )
+{return 1;}
+
+  FT_EXPORT( FT_Error )
+  FT_Get_Kerning( FT_Face     face,
+                  FT_UInt     left_glyph,
+                  FT_UInt     right_glyph,
+                  FT_UInt     kern_mode,
+                  FT_Vector  *akerning )
+{return 0;}
+
+  FT_EXPORT( FT_Error )
+  FT_Load_Glyph( FT_Face   face,
+                 FT_UInt   glyph_index,
+                 FT_Int32  load_flags )
+{return 0;}
+          
+  FT_EXPORT( FT_Error )
+  FT_Render_Glyph( FT_GlyphSlot    slot,
+                   FT_Render_Mode  render_mode )
+{return 0;}
+
+  FT_EXPORT( FT_Error )
+  FT_Init_FreeType( FT_Library  *alibrary )
+{return 0;}
+
+  FT_EXPORT( FT_Error )
+  FT_New_Face( FT_Library   library,
+               const char*  filepathname,
+               FT_Long      face_index,
+               FT_Face     *aface )
+{return 0;}
+
+  FT_EXPORT( FT_Error )
+  FT_Set_Char_Size( FT_Face     face,
+                    FT_F26Dot6  char_width,
+                    FT_F26Dot6  char_height,
+                    FT_UInt     horz_resolution,
+                    FT_UInt     vert_resolution )               
+{return 0;}
+
+  FT_EXPORT( FT_Error )
+  FT_Done_Face( FT_Face  face )
+{return 0;}
+
+  FT_EXPORT( FT_Error )
+  FT_Done_FreeType( FT_Library  library )
+{return 0;}
+
+
+/* ************************************************************************ */
+/* jpeglib.h */
+
+EXTERN(struct jpeg_error_mgr *) jpeg_std_error(struct jpeg_error_mgr *err)
+{return 0;}
+
+EXTERN(void) jpeg_CreateCompress(j_compress_ptr cinfo, int version,
+                                 size_t structsize)
+{return ;}
+
+EXTERN(void) jpeg_set_defaults(j_compress_ptr cinfo)
+{return ;}
+
+EXTERN(void) jpeg_set_quality(j_compress_ptr cinfo, int quality,
+                              boolean force_baseline)
+{return ;}
+
+EXTERN(void) jpeg_start_compress(j_compress_ptr cinfo,
+                                 boolean write_all_tables)
+{return ;}
+
+EXTERN(JDIMENSION) jpeg_write_scanlines(j_compress_ptr cinfo,
+                                        JSAMPARRAY scanlines,
+                                        JDIMENSION num_lines)
+{return 0;}
+
+EXTERN(void) jpeg_finish_compress(j_compress_ptr cinfo)
+{return ;}
+
+EXTERN(void) jpeg_destroy_compress(j_compress_ptr cinfo)
+{return ;}
+
+
+/* ************************************************************************ */


### PR DESCRIPTION
This patch removes the dependencies with these "unused" libraries:
- fontconfig
- freetype2
- jpeg

The "w_scan_cpp" tool is a command line only tool. Therefore these external libraries required by the VDR are fully unnecessary. We can then compile with fake (empty) functions instead of the original library. This have sense when you don't want to install the shared library in the target machine to run the tool. However, you need to library to compile it.

All the code is isolated in the small file "/micro/fake-layer.cpp". This file has a empty body of all functions used by the VDR part and the plugins. The content of this file is a pure "copy&paste" from the header part of the libraries (free to use) with a simple return body. The file only includes the necessary functions. If in the future any other function will be used the inner part of the tool, then it will be necessary to copy the declaration from the library and add a corresponding return value.