### PR TITLE
Add SRC support for SAT>IP

### DIFF
--- a/CmdOpts.cpp
+++ b/CmdOpts.cpp
@@ -401,7 +401,13 @@ bool ParseArguments(int argc, char* argv[]) {
         Message("Using RTP over TCP.");
         satip->SetupParse("TransportMode", "2");
         }
+
+     if (WirbelscanSetup.DVB_Type == 2 /* S */ && not DiseqcSwitch.empty()) {
+        cSource *fs = new cSource('S',"");
+        fs->Parse((Source + " " + std::to_string(std::stol(DiseqcSwitch))).c_str())
+        Sources.Add(fs);
      }
+  }
 
   switch(WirbelscanSetup.DVB_Type) {
      case 5 /* A */: break;

--- a/CmdOpts.cpp
+++ b/CmdOpts.cpp
@@ -404,7 +404,7 @@ bool ParseArguments(int argc, char* argv[]) {
 
      if (WirbelscanSetup.DVB_Type == 2 /* S */ && not DiseqcSwitch.empty()) {
         cSource *fs = new cSource('S',"");
-        fs->Parse((Source + " " + std::to_string(std::stol(DiseqcSwitch))).c_str())
+        fs->Parse((Source + " " + std::to_string(std::stol(DiseqcSwitch))).c_str());
         Sources.Add(fs);
      }
   }


### PR DESCRIPTION
Pass the SRC parameter to the SAT>IP server using the DiseqC value from the parameter "-D". All values for committed and uncommitted are valid.