### PR TITLE
Add all pids of the service with SAT>IP

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,6 +40,7 @@ Lars Theorin
  - for reporting that the option --satip-server was broken and providing an
    initial patch
  - for an initial patch to enable RTP over TCP on SAT>IP
+ - for including all service pids in the VLC SAT>IP output
 
 Manuel Reimer
  - for pointing to FTBC on wirbelscan plugin (missing <cstdint> in countries.h)

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -41,6 +41,7 @@ Lars Theorin
    initial patch
  - for an initial patch to enable RTP over TCP on SAT>IP
  - for fixing the SRC parameter with --output-VLC-satip
+ - for including all service pids in the VLC SAT>IP output
 
 Manuel Reimer
  - for pointing to FTBC on wirbelscan plugin (missing <cstdint> in countries.h)

--- a/HISTORY
+++ b/HISTORY
@@ -187,5 +187,5 @@
   to convert quotation mark, ampersand, apostrophe, less-than sign,
   greater-than sign to the five default XML char entities.
 * prefer StrToInt and LeftFill/RightFill in output formats
-* include all service pids in the VLC SAT>IP output
 * fix SRC parameter with VLC output for SAT>IP
+* include all service pids in the VLC SAT>IP output

--- a/HISTORY
+++ b/HISTORY
@@ -187,4 +187,5 @@
   to convert quotation mark, ampersand, apostrophe, less-than sign,
   greater-than sign to the five default XML char entities.
 * prefer StrToInt and LeftFill/RightFill in output formats
+* include all service pids in the VLC SAT>IP output
 * fix SRC parameter with VLC output for SAT>IP

--- a/HISTORY
+++ b/HISTORY
@@ -187,4 +187,4 @@
   to convert quotation mark, ampersand, apostrophe, less-than sign,
   greater-than sign to the five default XML char entities.
 * prefer StrToInt and LeftFill/RightFill in output formats
-* include all service pids in the VLC outputs
+* include all service pids in the VLC SAT>IP output

--- a/HISTORY
+++ b/HISTORY
@@ -187,3 +187,4 @@
   to convert quotation mark, ampersand, apostrophe, less-than sign,
   greater-than sign to the five default XML char entities.
 * prefer StrToInt and LeftFill/RightFill in output formats
+* include all service pids in the VLC outputs

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -1190,15 +1190,12 @@ void PrintVLCsatip(std::vector<TChannel>& List) {
         }
 
      ss << "&amp;pids=0,16,17,18";
-     if (c.PMT > 0)           ss << ',' << c.PMT;
-     if (c.VPID.PID > 0)      ss << ',' << c.VPID.PID;
-     for (int i=0; i < c.APIDs.Count(); i++)
-                              ss << ',' << c.APIDs[i].PID;
-     for (int i=0; i < c.DPIDs.Count(); i++)
-                              ss << ',' << c.DPIDs[i].PID;
-     for (int i=0; i < c.SPIDs.Count(); i++)
-                              ss << ',' << c.SPIDs[i].PID;
-     if (c.TPID > 0)          ss << ',' << c.TPID;
+     if (c.PMT > 0)                        ss << ',' << c.PMT;
+     if (c.VPID.PID > 0)                   ss << ',' << c.VPID.PID;
+     for (int i=0; i<c.APIDs.Count(); i++) ss << ',' << c.APIDs[i].PID;
+     for (int i=0; i<c.DPIDs.Count(); i++) ss << ',' << c.DPIDs[i].PID;
+     for (int i=0; i<c.SPIDs.Count(); i++) ss << ',' << c.SPIDs[i].PID;
+     if (c.TPID > 0)                       ss << ',' << c.TPID;
      ss << "</location>" << std::endl;
 
      ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -1192,11 +1192,11 @@ void PrintVLCsatip(std::vector<TChannel>& List) {
      ss << "&amp;pids=0,16,17,18";
      if (c.PMT > 0)           ss << ',' << c.PMT;
      if (c.VPID.PID > 0)      ss << ',' << c.VPID.PID;
-     if (c.APIDs.Count() > 0) for (int i=0; i < c.APIDs.Count(); i++)
+     for (int i=0; i < c.APIDs.Count(); i++)
                               ss << ',' << c.APIDs[i].PID;
-     if (c.DPIDs.Count() > 0) for (int i=0; i < c.DPIDs.Count(); i++)
+     for (int i=0; i < c.DPIDs.Count(); i++)
                               ss << ',' << c.DPIDs[i].PID;
-     if (c.SPIDs.Count() > 0) for (int i=0; i < c.SPIDs.Count(); i++)
+     for (int i=0; i < c.SPIDs.Count(); i++)
                               ss << ',' << c.SPIDs[i].PID;
      if (c.TPID > 0)          ss << ',' << c.TPID;
      ss << "</location>" << std::endl;

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -1192,8 +1192,12 @@ void PrintVLCsatip(std::vector<TChannel>& List) {
      ss << "&amp;pids=0,16,17,18";
      if (c.PMT > 0)           ss << ',' << c.PMT;
      if (c.VPID.PID > 0)      ss << ',' << c.VPID.PID;
-     if (c.APIDs.Count() > 0) ss << ',' << c.APIDs[0].PID;
-     if (c.DPIDs.Count() > 0) ss << ',' << c.DPIDs[0].PID;        
+     if (c.APIDs.Count() > 0) for (int i=0; i < c.APIDs.Count(); i++)
+                              ss << ',' << c.APIDs[i].PID;
+     if (c.DPIDs.Count() > 0) for (int i=0; i < c.DPIDs.Count(); i++)
+                              ss << ',' << c.DPIDs[i].PID;
+     if (c.SPIDs.Count() > 0) for (int i=0; i < c.SPIDs.Count(); i++)
+                              ss << ',' << c.SPIDs[i].PID;
      if (c.TPID > 0)          ss << ',' << c.TPID;
      ss << "</location>" << std::endl;
 


### PR DESCRIPTION
This patch adds all pids of the service in the XSPF output when using SAT>IP.