### PR TITLE
Set SATIP LOG to DbgToStderr

### DIFF
--- a/CmdOpts.cpp
+++ b/CmdOpts.cpp
@@ -396,7 +396,7 @@ bool ParseArguments(int argc, char* argv[]) {
      }
 
   if (use_satip) {
-     std::string options("-t 16384");
+     std::string options("-t 65536"); // Set LOG to DbgToStderr
      bool RtpOverTcp = false;
 
      // add further satip plugin options as needed.


### PR DESCRIPTION
Initialize the SATIP plugin with debug enabled to the STDERR. Without this patch the debug lines will be included in the output file. This patch solves the problem.

Note: It requires a version of the 'vdr-plugin-satip' supporting the 'eDebugMode:DbgToStderr' flag.