### PR TITLE
Refactoring of VLC outputs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,6 +42,7 @@ Lars Theorin
  - for an initial patch to enable RTP over TCP on SAT>IP
  - for fixing the SRC parameter with --output-VLC-satip
  - for including all service pids in the VLC SAT>IP output
+ - for refactoring the VLC outputs
 
 Manuel Reimer
  - for pointing to FTBC on wirbelscan plugin (missing <cstdint> in countries.h)

--- a/HISTORY
+++ b/HISTORY
@@ -189,3 +189,4 @@
 * prefer StrToInt and LeftFill/RightFill in output formats
 * fix SRC parameter with VLC output for SAT>IP
 * include all service pids in the VLC SAT>IP output
+* refactoring of the VLC outputs, which now include the generation date

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -826,27 +826,27 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
         while(freq_MHz and (freq_MHz > 1000.0)) freq_MHz /= 1000.0;
         }
 
-     if (c.Source == "A" and !satip) {
+     if (!satip and c.Source == "A") {
         ss << INDENT << "<location>atsc://frequency="  << freq_Hz << "</location>" << std::endl;
         }
-     if (c.Source == "C" and !satip) {
+     if (!satip and c.Source == "C") {
         ss << INDENT << "<location>dvb-c://frequency=" << freq_Hz << "</location>" << std::endl;
         }
-     if (c.Source == "T" and !satip) {
+     if (!satip and c.Source == "T") {
         ss << INDENT << "<location>dvb-t";
         if (c.DelSys == 1) ss << "2";
         ss << "://frequency=" << freq_Hz << "</location>" << std::endl;
         }
-     if (c.Source.find('S') == 0 and !satip) {
+     if (!satip and c.Source.find('S') == 0) {
         ss << INDENT << "<location>dvb-s";
         if (c.DelSys == 1) ss << "2";
         }
 
-     if (c.Source == "A" and satip) {
+     if (satip and c.Source == "A") {
         ErrorMessage("ATSC is not yet supported in SAT>IP");
         return;
         }
-     if (c.Source == "C" and satip) {
+     if (satip and c.Source == "C") {
         ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
                                           ss << "freq=" << freq_MHz;
         if (c.DelSys == 0) {
@@ -870,7 +870,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
            if (c.StreamId != 999)         ss << "&amp;plp=" << c.StreamId;
            }
         }
-     if (c.Source == "T" and satip) {
+     if (satip and c.Source == "T") {
         ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
                                        ss << "freq=" << freq_MHz;
         double bw = c.Bandwidth;
@@ -913,7 +913,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
                                        ss << "&amp;sm="   << c.MISO;
            }
         }
-     if ((c.Source.find('S') == 0) and satip) {
+     if (satip and (c.Source.find('S') == 0)) {
         ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
                                ss << "src="       << src;
                                ss << "&amp;freq=" << c.Frequency;
@@ -958,7 +958,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
         ss << "</location>" << std::endl;
         }
 
-     if (c.Source == "A" and !satip) {
+     if (!satip and c.Source == "A") {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 
@@ -989,7 +989,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
            ss << "</vlc:option>" << std::endl;
            }
         }
-     if (c.Source == "C" and !satip) {
+     if (!satip and c.Source == "C") {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 
@@ -1016,7 +1016,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
         if (c.Inversion != 999)
            ss << INDENT << "<vlc:option>" << "dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
         }
-     if (c.Source == "T" and !satip) {
+     if (!satip and c.Source == "T") {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 
@@ -1089,7 +1089,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
               ss << INDENT << "<vlc:option>" << "dvb-plp-id=" << c.StreamId << "</vlc:option>" << std::endl;
            }
         }
-     if ((c.Source.find('S') == 0) and !satip) {
+     if (!satip and (c.Source.find('S') == 0)) {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -762,9 +762,9 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
   auto sec   = IntToStr(0    + tm->tm_sec , 2, false, '0');
   int src = 1;
   cSource* source = Sources.First();
-  if (source && source->Description())
+  if (source and source->Description())
       src = strtol(source->Description(), NULL, 0);
-  if (src < 1 || src > 255)
+  if (src < 1 or src > 255)
       src = 1;
 
   ss << INDENT << "<?xml"
@@ -816,34 +816,34 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
         auto freq_Min = [](std::string Source) -> uint64_t {
             return (Source.find('S') == 0) ? 3000000000ULL : 50000000ULL;
             };
-        while(freq_Hz && (freq_Hz < freq_Min(c.Source))) freq_Hz *= 1000;
+        while(freq_Hz and (freq_Hz < freq_Min(c.Source))) freq_Hz *= 1000;
         }
      else {
-        while(freq_Hz  && (freq_Hz < 1000000)) freq_Hz  *= 1000;
-        while(freq_MHz && (freq_MHz > 1000.0)) freq_MHz /= 1000.0;
+        while(freq_Hz  and (freq_Hz < 1000000)) freq_Hz  *= 1000;
+        while(freq_MHz and (freq_MHz > 1000.0)) freq_MHz /= 1000.0;
         }
 
-     if (c.Source == "A" && !satip) {
+     if (c.Source == "A" and !satip) {
         ss << INDENT << "<location>atsc://frequency="  << freq_Hz << "</location>" << std::endl;
         }
-     if (c.Source == "C" && !satip) {
+     if (c.Source == "C" and !satip) {
         ss << INDENT << "<location>dvb-c://frequency=" << freq_Hz << "</location>" << std::endl;
         }
-     if (c.Source == "T" && !satip) {
+     if (c.Source == "T" and !satip) {
         ss << INDENT << "<location>dvb-t";
         if (c.DelSys == 1) ss << "2";
         ss << "://frequency=" << freq_Hz << "</location>" << std::endl;
         }
-     if (c.Source.find('S') == 0 && !satip) {
+     if (c.Source.find('S') == 0 and !satip) {
         ss << INDENT << "<location>dvb-s";
         if (c.DelSys == 1) ss << "2";
         }
 
-     if (c.Source == "A" && satip) {
+     if (c.Source == "A" and satip) {
         ErrorMessage("ATSC is not yet supported in SAT>IP");
         return;
         }
-     if (c.Source == "C" && satip) {
+     if (c.Source == "C" and satip) {
         ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
                                           ss << "freq=" << freq_MHz;
         if (c.DelSys == 0) {
@@ -867,7 +867,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
            if (c.StreamId != 999)         ss << "&amp;plp=" << c.StreamId;
            }
         }
-     if (c.Source == "T" && satip) {
+     if (c.Source == "T" and satip) {
         ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
                                        ss << "freq=" << freq_MHz;
         double bw = c.Bandwidth;
@@ -910,7 +910,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
                                        ss << "&amp;sm="   << c.MISO;
            }
         }
-     if ((c.Source.find('S') == 0) && satip) {
+     if ((c.Source.find('S') == 0) and satip) {
         ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
                                ss << "src="       << src;
                                ss << "&amp;freq=" << c.Frequency;
@@ -955,7 +955,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
         ss << "</location>" << std::endl;
         }
 
-     if (c.Source == "A" && !satip) {
+     if (c.Source == "A" and !satip) {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 
@@ -968,7 +968,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
 
         if (c.LCN != -1)
            ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
-        if (c.LCN != -1 && c.LCN_minor != -1)
+        if (c.LCN != -1 and c.LCN_minor != -1)
            ss << INDENT << "<vlc:option>" << "logical-channel-number-minor=" << c.LCN_minor << "</vlc:option>" << std::endl;
 
         ss << INDENT << "<vlc:option>" << "dvb-ts-id=" << c.TID << "</vlc:option>" << std::endl;
@@ -986,7 +986,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
            ss << "</vlc:option>" << std::endl;
            }
         }
-     if (c.Source == "C" && !satip) {
+     if (c.Source == "C" and !satip) {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 
@@ -1013,7 +1013,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
         if (c.Inversion != 999)
            ss << INDENT << "<vlc:option>" << "dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
         }
-     if (c.Source == "T" && !satip) {
+     if (c.Source == "T" and !satip) {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 
@@ -1086,7 +1086,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
               ss << INDENT << "<vlc:option>" << "dvb-plp-id=" << c.StreamId << "</vlc:option>" << std::endl;
            }
         }
-     if ((c.Source.find('S') == 0) && !satip) {
+     if ((c.Source.find('S') == 0) and !satip) {
         ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
         indent++;
 

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -753,15 +753,20 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
   std::stringstream ss;
   size_t indent = 0;
 
-  auto t = time(nullptr);
-  auto tm = localtime(&t);
-  std::stringstream date; // "yyyy.mm.ddTHH:MM:SS"
-  date <<        IntToStr(1900 + tm->tm_year, 4, false, '0');
-  date << "-" << IntToStr(1    + tm->tm_mon , 2, false, '0');
-  date << "-" << IntToStr(0    + tm->tm_mday, 2, false, '0');
-  date << "T" << IntToStr(0    + tm->tm_hour, 2, false, '0');
-  date << ":" << IntToStr(0    + tm->tm_min , 2, false, '0');
-  date << ":" << IntToStr(0    + tm->tm_sec , 2, false, '0');
+  std::stringstream sdate;
+  std::string date; // "yyyy.mm.ddTHH:MM:SS"
+  time_t timeepoch;
+  struct tm timeinfo;
+  if (time(&timeepoch) > 0)
+      if (localtime_r(&timeepoch, &timeinfo)) {
+          sdate <<        IntToStr(1900 + timeinfo.tm_year, 4, false, '0');
+          sdate << "-" << IntToStr(1    + timeinfo.tm_mon , 2, false, '0');
+          sdate << "-" << IntToStr(0    + timeinfo.tm_mday, 2, false, '0');
+          sdate << "T" << IntToStr(0    + timeinfo.tm_hour, 2, false, '0');
+          sdate << ":" << IntToStr(0    + timeinfo.tm_min , 2, false, '0');
+          sdate << ":" << IntToStr(0    + timeinfo.tm_sec , 2, false, '0');
+      }
+  date = sdate.str();
 
   int src = 1;
   cSource* source = Sources.First();
@@ -784,7 +789,8 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
 
   ss << INDENT << "<title>DVB Playlist</title>" << std::endl;
   ss << INDENT << "<creator>w_scan_cpp</creator>" << std::endl;
-  ss << INDENT << "<date>" << date.str() << "</date>" << std::endl;
+  if (!date.empty())
+      ss << INDENT << "<date>" << date << "</date>" << std::endl;
   ss << INDENT << "<info>https://gen2vdr.de/wirbel/w_scan_cpp/index2.html</info>" << std::endl;
   ss << INDENT << "<trackList>" << std::endl;
   indent++;

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -749,9 +749,23 @@ void XmlString(std::string& s) {
   ReplaceAll(s, "\"", "&quot;");
 }
 
-void PrintVLC(std::vector<TChannel>& List) {
+void PrintVLCcommon(std::vector<TChannel>& List, bool satip) {
   std::stringstream ss;
   size_t indent = 0;
+  auto t = time(nullptr);
+  auto tm = localtime(&t);
+  auto year  = IntToStr(1900 + tm->tm_year, 4, false, '0');
+  auto month = IntToStr(1    + tm->tm_mon , 2, false, '0');
+  auto day   = IntToStr(0    + tm->tm_mday, 2, false, '0');
+  auto hour  = IntToStr(0    + tm->tm_hour, 2, false, '0');
+  auto min   = IntToStr(0    + tm->tm_min , 2, false, '0');
+  auto sec   = IntToStr(0    + tm->tm_sec , 2, false, '0');
+  int src = 1;
+  cSource* source = Sources.First();
+  if (source && source->Description())
+      src = strtol(source->Description(), NULL, 0);
+  if (src < 1 || src > 255)
+      src = 1;
 
   ss << INDENT << "<?xml"
      << " version="  << '"' << "1.0"   << '"'
@@ -767,6 +781,7 @@ void PrintVLC(std::vector<TChannel>& List) {
 
   ss << INDENT << "<title>DVB Playlist</title>" << std::endl;
   ss << INDENT << "<creator>w_scan_cpp</creator>" << std::endl;
+  ss << INDENT << "<date>" + year + "-" + month + "-" + day + "T" + hour + ":" + min + ":" + sec + "</date>" << std::endl;
   ss << INDENT << "<info>https://gen2vdr.de/wirbel/w_scan_cpp/index2.html</info>" << std::endl;
   ss << INDENT << "<trackList>" << std::endl;
   indent++;
@@ -795,334 +810,69 @@ void PrintVLC(std::vector<TChannel>& List) {
      ss << INDENT << "<title>" << title << "</title>" << std::endl;
 
      uint64_t freq_Hz = c.Frequency;
-     auto freq_Min = [](std::string Source) -> uint64_t {
-        return (Source.find('S') == 0) ? 3000000000ULL : 50000000ULL;
-        };
+     double freq_MHz = c.Frequency;
 
-     while(freq_Hz && (freq_Hz < freq_Min(c.Source))) freq_Hz *= 1000;
-
-     if (c.Source == "A") {
-        ss << INDENT << "<location>atsc://frequency=" << freq_Hz << "</location>" << std::endl;
-
-        ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
-        indent++;
-
-        ss << INDENT << "<vlc:id>" << TitleNumber;
-        if (c.LCN_minor != -1)
-           ss << "." << c.LCN_minor;
-        ss << "</vlc:id>" << std::endl;
-
-        if (c.LCN != -1) {
-           ss << INDENT << "<vlc:option>"
-              << "logical-channel-number=" << c.LCN
-              << "</vlc:option>" << std::endl;
-           if (c.LCN_minor != -1)
-              ss << INDENT << "<vlc:option>"
-                 << "logical-channel-number-minor=" << c.LCN_minor
-                 << "</vlc:option>" << std::endl;
-           }
-
-        ss << INDENT << "<vlc:option>" << "dvb-ts-id=" << c.TID << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "program="   << c.SID << "</vlc:option>" << std::endl;
-
-        if (c.Modulation != 999) {
-           ss << INDENT << "<vlc:option>dvb-modulation=";
-	        if (c.Modulation == 10)         ss << "8VSB";
-	        else if (c.Modulation == 11)    ss << "16VSB";
-	        else if (c.Modulation == 64)    ss << "64QAM"; // may be unused at all.
-	        else if (c.Modulation == 256)   ss << "256QAM";
-           else                            ss << "AUTO";
-           ss << "</vlc:option>" << std::endl;
-           }
-
-        indent--;
-        ss << INDENT << "</extension>" << std::endl;
+     if (!satip) {
+        auto freq_Min = [](std::string Source) -> uint64_t {
+            return (Source.find('S') == 0) ? 3000000000ULL : 50000000ULL;
+            };
+        while(freq_Hz && (freq_Hz < freq_Min(c.Source))) freq_Hz *= 1000;
         }
-     if (c.Source == "C") {
+     else {
+        while(freq_Hz  && (freq_Hz < 1000000)) freq_Hz  *= 1000;
+        while(freq_MHz && (freq_MHz > 1000.0)) freq_MHz /= 1000.0;
+        }
+
+     if (c.Source == "A" && !satip) {
+        ss << INDENT << "<location>atsc://frequency="  << freq_Hz << "</location>" << std::endl;
+        }
+     if (c.Source == "C" && !satip) {
         ss << INDENT << "<location>dvb-c://frequency=" << freq_Hz << "</location>" << std::endl;
-
-        ss << INDENT << "<extension" << " application=" << '"' << AppUrl << '"' << ">" << std::endl;
-        indent++;
-
-        if (c.LCN != -1)
-           ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
-
-        ss << INDENT << "<vlc:id>"     << TitleNumber  << "</vlc:id>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-ts-id=" << c.TID             << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "program="   << c.SID << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-srate=" << c.Symbolrate*1000 << "</vlc:option>" << std::endl;
-
-        if (c.Modulation != 999) {
-           ss << INDENT << "<vlc:option>" << "dvb-modulation=";
-	        if (c.Modulation == 32)         ss << "32QAM";
-	        else if (c.Modulation == 64)    ss << "64QAM";
-	        else if (c.Modulation == 128)   ss << "128QAM";
-	        else if (c.Modulation == 256)   ss << "256QAM";
-           else                            ss << "AUTO";
-           ss << "</vlc:option>" << std::endl;
-           }
-        if (c.Inversion != 999) {
-           ss << INDENT << "<vlc:option>" << "dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
-           }
-
-        indent--;
-        ss << INDENT << "</extension>" << std::endl;
         }
-     if (c.Source == "T") {
+     if (c.Source == "T" && !satip) {
         ss << INDENT << "<location>dvb-t";
         if (c.DelSys == 1) ss << "2";
         ss << "://frequency=" << freq_Hz << "</location>" << std::endl;
-
-        ss << INDENT << "<extension" << " application=" << '"' << AppUrl << '"' << ">" << std::endl;
-        indent++;
-
-        if (c.LCN != -1)
-           ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
-
-        int bw = c.Bandwidth;
-        while(bw > 999) bw = round(bw/1000.0);
-
-        ss << INDENT << "<vlc:id>"     << TitleNumber      << "</vlc:id>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-ts-id="     << c.TID << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "program="       << c.SID << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-bandwidth=" << bw    << "</vlc:option>" << std::endl;
-
-        if (c.Inversion    != 999)
-           ss << INDENT << "<vlc:option>dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
-        if (c.FEC          != 999) {
-           ss << INDENT << "<vlc:option>dvb-code-rate-hp=";
-	        if (c.FEC == 12)         ss << "1/2";
-	        else if (c.FEC == 23)    ss << "2/3";
-	        else if (c.FEC == 34)    ss << "3/4";
-	        else if (c.FEC == 45)    ss << "4/5";
-	        else if (c.FEC == 56)    ss << "5/6";
-	        else if (c.FEC == 67)    ss << "6/7";
-	        else if (c.FEC == 78)    ss << "7/8";
-	        else if (c.FEC == 35)    ss << "3/5";
-	        else if (c.FEC == 89)    ss << "8/9";
-	        else if (c.FEC == 910)   ss << "9/10";
-	        else if (c.FEC == 25)    ss << "2/5";
-	        else if (c.FEC == 14)    ss << "1/4";
-	        else if (c.FEC == 13)    ss << "1/3";
-           else                     ss << "-1";
-           ss << "</vlc:option>" << std::endl;
-           }
-        if (c.Modulation != 999) {
-           ss << INDENT << "<vlc:option>" << "dvb-modulation=";
-	        if (c.Modulation == 2)        ss << "QPSK";
-	        else if (c.Modulation == 16)  ss << "16QAM";
-	        else if (c.Modulation == 64)  ss << "64QAM";
-	        else if (c.Modulation == 256) ss << "256QAM";
-           else                          ss << "AUTO";
-           ss << "</vlc:option>" << std::endl;
-           }
-        if (c.Transmission != 999)
-           ss << INDENT << "<vlc:option>" << "dvb-transmission=" << c.Transmission << "</vlc:option>" << std::endl;
-        if (c.Guard != 999) {
-           ss << INDENT << "<vlc:option>" << "dvb-guard=";
-	        if (c.Guard == 4)             ss << "1/4";
-	        else if (c.Guard == 8)        ss << "1/8";
-	        else if (c.Guard == 16)       ss << "1/16";
-	        else if (c.Guard == 32)       ss << "1/32";
-	        else if (c.Guard == 128)      ss << "1/128";
-	        else if (c.Guard == 19128)    ss << "19/128";
-	        else if (c.Guard == 19256)    ss << "19/256";
-           else                          ss << "AUTO";
-           ss << "</vlc:option>" << std::endl;
-           }
-        if (c.DelSys == 1) {
-           if (c.StreamId  != 999)
-              ss << INDENT << "<vlc:option>" << "dvb-plp-id=" << c.StreamId << "</vlc:option>" << std::endl;
-           }
-        indent--;
-        ss << INDENT << "</extension>" << std::endl;
         }
-     if (c.Source.find('S') == 0) {
+     if (c.Source.find('S') == 0 && !satip) {
         ss << INDENT << "<location>dvb-s";
         if (c.DelSys == 1) ss << "2";
-        ss << "://frequency=" << freq_Hz << "</location>" << std::endl;
-
-        ss << INDENT << "<extension" << " application=" << '"' << AppUrl << '"' << ">" << std::endl;
-        indent++;
-
-        if (c.LCN != -1)
-           ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
-
-        ss << INDENT << "<vlc:id>"     << TitleNumber         << "</vlc:id>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-ts-id="        << c.TID << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "program="          << c.SID << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-polarization=" << c.Polarization << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-srate="        << c.Symbolrate*1000 << "</vlc:option>" << std::endl;
-        if (c.Inversion    != 999)
-           ss << INDENT << "<vlc:option>dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
-        if (c.FEC          != 999) {
-           ss << INDENT << "<vlc:option>dvb-fec=";
-	        if (c.FEC == 12)       ss << "1/2";
-	        else if (c.FEC == 23)  ss << "2/3";
-	        else if (c.FEC == 34)  ss << "3/4";
-	        else if (c.FEC == 45)  ss << "4/5";
-	        else if (c.FEC == 56)  ss << "5/6";
-	        else if (c.FEC == 67)  ss << "6/7";
-	        else if (c.FEC == 78)  ss << "7/8";
-	        else if (c.FEC == 89)  ss << "8/9";
-	        else if (c.FEC == 35)  ss << "3/5";
-	        else if (c.FEC == 910) ss << "9/10";
-	        else if (c.FEC == 25)  ss << "2/5";
-	        else if (c.FEC == 14)  ss << "1/4";
-	        else if (c.FEC == 13)  ss << "1/3";
-           else                   ss << "-1";
-           ss << "</vlc:option>" << std::endl;
-           }
-        if (c.DelSys == 1) {
-           if (c.StreamId  != 999)
-              ss << INDENT << "<vlc:option>" << "dvb-plp-id=" << c.StreamId << "</vlc:option>" << std::endl;
-           ss << INDENT << "<vlc:option>" << "dvb-modulation=";
-	        if (c.Modulation == 2)       ss << "QPSK";
-	        else if (c.Modulation == 5)  ss << "8PSK";
-	        else if (c.Modulation == 6)  ss << "16APSK";
-	        else if (c.Modulation == 7)  ss << "32APSK";
-           else if (c.Modulation == 12) ss << "DQPSK";
-           else                         ss << "AUTO";
-           ss << "</vlc:option>" << std::endl;
-
-           ss << INDENT << "<vlc:option>" << "dvb-rolloff=";
-           if (c.Rolloff == 20)         ss << 20;
-           else if (c.Rolloff == 25)    ss << 25;
-           else                         ss << 35;
-           ss << "</vlc:option>" << std::endl;
-           }
-
-        int h,l,s;
-        GetLnb(l, h, s);
-        ss << INDENT << "<vlc:option>" << "dvb-lnb-low="    << l << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-lnb-high="   << h << "</vlc:option>" << std::endl;
-        ss << INDENT << "<vlc:option>" << "dvb-lnb-switch=" << s << "</vlc:option>" << std::endl;
-
-        if (DiseqcSwitchPosition() != -1)
-           ss << INDENT << "<vlc:option>" << "dvb-satno=" << DiseqcSwitchPosition() << "</vlc:option>" << std::endl;
-
-        indent--;
-        ss << INDENT << "</extension>" << std::endl;
         }
 
-     TitleNumber++;
-     indent--;
-     ss << INDENT << "</track>" << std::endl;
-     } // end for()
-
-  indent--;
-  ss << INDENT << "</trackList>" << std::endl;
-
-  indent--;
-  ss << INDENT << "</playlist>" << std::endl;
-
-  OutputLine(ss.str());
-}
-
-
-/*******************************************************************************
- * VLC satip output
- ******************************************************************************/
-
-void PrintVLCsatip(std::vector<TChannel>& List) {
-  std::stringstream ss;
-  size_t indent = 0;
-  int src = 1;
-  cSource* source = Sources.First();
-  if (source && source->Description())
-      src = strtol(source->Description(), NULL, 0);
-  if (src < 1 || src > 255)
-      src = 1;
-
-  ss << INDENT << "<?xml"
-     << " version="  << '"' << "1.0"   << '"'
-     << " encoding=" << '"' << "UTF-8" << '"'
-     << "?>" << std::endl;
-
-  ss << INDENT << "<playlist"
-     << " version="   << '"' << "1" << '"'
-     << " xmlns="     << '"' << "http://xspf.org/ns/0/" << '"'
-     << " xmlns:vlc=" << '"' << "http://www.videolan.org/vlc/playlist/ns/0/" << '"'
-     << '>' << std::endl;
-  indent++;
-
-  ss << INDENT << "<title>DVB Playlist</title>" << std::endl;
-  ss << INDENT << "<creator>w_scan_cpp</creator>" << std::endl;
-  ss << INDENT << "<info>https://gen2vdr.de/wirbel/w_scan_cpp/index2.html</info>" << std::endl;
-  ss << INDENT << "<trackList>" << std::endl;
-  indent++;
-
-  const char* AppUrl = "http://www.videolan.org/vlc/playlist/0";
-  size_t TitleNumber = 1;
-
-  for(auto c:UniqueChannels(List)) {
-     ss << INDENT << "<track>" << std::endl;
-     indent++;
-
-     if (c.LCN != -1)
-        TitleNumber = c.LCN;
-     ss << INDENT << "<trackNum>" << IntToStr(TitleNumber);
-     if (c.Source == "A" and c.LCN_minor != -1)
-        ss << "." << c.LCN_minor;
-     ss << "</trackNum>" << std::endl;
-
-     std::string title;
-     if (not c.Name.empty()) {
-        title = c.Name;
-        XmlString(title);
-        }
-     else
-        title += ". Channel";
-     ss << INDENT << "<title>" << title << "</title>" << std::endl;
-
-     uint32_t freq_Hz;
-     double freq_MHz;
-
-     freq_Hz = c.Frequency;
-     freq_MHz = c.Frequency;     
-     while(freq_Hz && (freq_Hz < 1000000)) freq_Hz *= 1000;
-     while(freq_MHz && (freq_MHz > 1000.0)) freq_MHz /= 1000.0;
-
-     ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
-
-     if (c.Source == "A") {
+     if (c.Source == "A" && satip) {
         ErrorMessage("ATSC is not yet supported in SAT>IP");
         return;
         }
-     if (c.Source == "C") {
-        ss << "freq=" << freq_MHz;
-        ss << "&amp;msys=dvbc";
+     if (c.Source == "C" && satip) {
+        ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
+                                          ss << "freq=" << freq_MHz;
         if (c.DelSys == 0) {
-	        if (c.Modulation == 16)         ss << "&amp;mtype=16qam";
-	        else if (c.Modulation == 32)    ss << "&amp;mtype=32qam";
-	        else if (c.Modulation == 64)    ss << "&amp;mtype=64qam";
-	        else if (c.Modulation == 128)   ss << "&amp;mtype=128qam";
-	        else if (c.Modulation == 256)   ss << "&amp;mtype=256qam";
+                                          ss << "&amp;msys=dvbc";
+           if      (c.Modulation == 16)   ss << "&amp;mtype=16qam";
+           else if (c.Modulation == 32)   ss << "&amp;mtype=32qam";
+           else if (c.Modulation == 64)   ss << "&amp;mtype=64qam";
+           else if (c.Modulation == 128)  ss << "&amp;mtype=128qam";
+           else if (c.Modulation == 256)  ss << "&amp;mtype=256qam";
 
-           ss << "&amp;sr=" << c.Symbolrate;
+           ss << "&amp;sr="      << c.Symbolrate;
 
-           if (c.Inversion != 999)
-              ss << "&amp;specinv=" << c.Inversion;
+           if (c.Inversion != 999)        ss << "&amp;specinv=" << c.Inversion;
            }
         else {
-           ss << "2"; // DVB-C2
-
+                                          ss << "&amp;msys=dvbc2";
            int bw = c.Bandwidth;
            while(bw > 999) bw = round(bw/1000.0);
 
-           if (bw != 999)
-              ss << "&amp;bw=" << bw;
-           if (c.StreamId != 999)
-              ss << "&amp;plp=" << c.StreamId;
+           if (bw != 999)                 ss << "&amp;bw="  << bw;
+           if (c.StreamId != 999)         ss << "&amp;plp=" << c.StreamId;
            }
-
         }
-     if (c.Source == "T") {
-        ss << "freq=" << freq_MHz;
-
+     if (c.Source == "T" && satip) {
+        ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
+                                       ss << "freq=" << freq_MHz;
         double bw = c.Bandwidth;
         while(bw >= 1000.0) bw /= 1000.0;
-        ss << "&amp;bw=" << bw;
+                                       ss << "&amp;bw=" << bw;
 
         if      (c.Transmission == 2)  ss << "&amp;tmode=2k";
         else if (c.Transmission == 4)  ss << "&amp;tmode=4k";
@@ -1131,44 +881,43 @@ void PrintVLCsatip(std::vector<TChannel>& List) {
         else if (c.Transmission == 16) ss << "&amp;tmode=16k";
         else if (c.Transmission == 32) ss << "&amp;tmode=32k";
 
-        if (c.Modulation == 2)        ss << "&amp;mtype=qpsk";
-        else if (c.Modulation == 16)  ss << "&amp;mtype=16qam";
-        else if (c.Modulation == 64)  ss << "&amp;mtype=64qam";
-        else if (c.Modulation == 256) ss << "&amp;mtype=256qam";
+        if      (c.Modulation == 2)    ss << "&amp;mtype=qpsk";
+        else if (c.Modulation == 16)   ss << "&amp;mtype=16qam";
+        else if (c.Modulation == 64)   ss << "&amp;mtype=64qam";
+        else if (c.Modulation == 256)  ss << "&amp;mtype=256qam";
 
-        if (c.Guard == 4)             ss << "&amp;gi=14";
-        else if (c.Guard == 8)        ss << "&amp;gi=18";
-        else if (c.Guard == 16)       ss << "&amp;gi=116";
-        else if (c.Guard == 32)       ss << "&amp;gi=132";
-        else if (c.Guard == 128)      ss << "&amp;gi=1128";
-        else if (c.Guard == 19128)    ss << "&amp;gi=19128";
-        else if (c.Guard == 19256)    ss << "&amp;gi=19256";
+        if      (c.Guard == 4)         ss << "&amp;gi=14";
+        else if (c.Guard == 8)         ss << "&amp;gi=18";
+        else if (c.Guard == 16)        ss << "&amp;gi=116";
+        else if (c.Guard == 32)        ss << "&amp;gi=132";
+        else if (c.Guard == 128)       ss << "&amp;gi=1128";
+        else if (c.Guard == 19128)     ss << "&amp;gi=19128";
+        else if (c.Guard == 19256)     ss << "&amp;gi=19256";
 
-        if (c.FEC == 12)         ss << "&amp;fec=12";
-        else if (c.FEC == 35)    ss << "&amp;fec=35";
-        else if (c.FEC == 23)    ss << "&amp;fec=23";
-        else if (c.FEC == 34)    ss << "&amp;fec=34";
-        else if (c.FEC == 45)    ss << "&amp;fec=45";
-        else if (c.FEC == 56)    ss << "&amp;fec=56";
-        else if (c.FEC == 78)    ss << "&amp;fec=78";
+        if      (c.FEC == 12)          ss << "&amp;fec=12";
+        else if (c.FEC == 35)          ss << "&amp;fec=35";
+        else if (c.FEC == 23)          ss << "&amp;fec=23";
+        else if (c.FEC == 34)          ss << "&amp;fec=34";
+        else if (c.FEC == 45)          ss << "&amp;fec=45";
+        else if (c.FEC == 56)          ss << "&amp;fec=56";
+        else if (c.FEC == 78)          ss << "&amp;fec=78";
 
-        if (c.DelSys == 0) {
-           ss << "&amp;msys=dvbt";
-           }
+        if (c.DelSys == 0)             ss << "&amp;msys=dvbt";
         else {
-           ss << "&amp;msys=dvbt2";
-           ss << "&amp;plp=" << c.StreamId;
-           ss << "&amp;t2id=" << c.SystemId;
-           ss << "&amp;sm=" << c.MISO;
-           }        
+                                       ss << "&amp;msys=dvbt2";
+                                       ss << "&amp;plp="  << c.StreamId;
+                                       ss << "&amp;t2id=" << c.SystemId;
+                                       ss << "&amp;sm="   << c.MISO;
+           }
         }
-     if (c.Source.find('S') == 0) {
-        ss << "src=" << src;
-        ss << "&amp;freq=" << c.Frequency;
-        ss << "&amp;pol=" << (char) std::tolower((unsigned char) c.Polarization);
-        ss << "&amp;sr=" << c.Symbolrate;
+     if ((c.Source.find('S') == 0) && satip) {
+        ss << INDENT << "<location>rtsp://" << WirbelscanSetup.SatipAddr << "/?";
+                               ss << "src="       << src;
+                               ss << "&amp;freq=" << c.Frequency;
+                               ss << "&amp;pol="  << (char) std::tolower((unsigned char) c.Polarization);
+                               ss << "&amp;sr="   << c.Symbolrate;
 
-        if (c.FEC == 12)       ss << "&amp;fec=12";
+        if      (c.FEC == 12)  ss << "&amp;fec=12";
         else if (c.FEC == 23)  ss << "&amp;fec=23";
         else if (c.FEC == 34)  ss << "&amp;fec=34";
         else if (c.FEC == 56)  ss << "&amp;fec=56";
@@ -1182,48 +931,255 @@ void PrintVLCsatip(std::vector<TChannel>& List) {
            ss << "&amp;ro=0.35&amp;msys=dvbs&amp;mtype=qpsk&amp;plts=off";
            }
         else {
-           if (c.Rolloff == 20)      ss << "&amp;ro=0.20";
-           else if (c.Rolloff == 25) ss << "&amp;ro=0.25";
-           else                      ss << "&amp;ro=0.35";
+           if      (c.Rolloff == 20)   ss << "&amp;ro=0.20";
+           else if (c.Rolloff == 25)   ss << "&amp;ro=0.25";
+           else                        ss << "&amp;ro=0.35";
 
            ss << "&amp;msys=dvbs2";
 
-	        if (c.Modulation == 2)       ss << "&amp;mtype=qpsk";
-	        else if (c.Modulation == 5)  ss << "&amp;mtype=8psk";
+           if      (c.Modulation == 2) ss << "&amp;mtype=qpsk";
+           else if (c.Modulation == 5) ss << "&amp;mtype=8psk";
 
-	        if (c.Pilot == 0) ss << "&amp;plts=off";
-	        else              ss << "&amp;plts=on";
+           if (c.Pilot == 0)           ss << "&amp;plts=off";
+           else                        ss << "&amp;plts=on";
            }
         }
+     if (satip) {
+        ss << "&amp;pids=0,16,17,18";
+        if  (c.PMT > 0)                       ss << ',' << c.PMT;
+        if  (c.VPID.PID > 0)                  ss << ',' << c.VPID.PID;
+        for (int i=0; i<c.APIDs.Count(); i++) ss << ',' << c.APIDs[i].PID;
+        for (int i=0; i<c.DPIDs.Count(); i++) ss << ',' << c.DPIDs[i].PID;
+        for (int i=0; i<c.SPIDs.Count(); i++) ss << ',' << c.SPIDs[i].PID;
+        if  (c.TPID > 0)                      ss << ',' << c.TPID;
+        ss << "</location>" << std::endl;
+        }
 
-     ss << "&amp;pids=0,16,17,18";
-     if (c.PMT > 0)                        ss << ',' << c.PMT;
-     if (c.VPID.PID > 0)                   ss << ',' << c.VPID.PID;
-     for (int i=0; i<c.APIDs.Count(); i++) ss << ',' << c.APIDs[i].PID;
-     for (int i=0; i<c.DPIDs.Count(); i++) ss << ',' << c.DPIDs[i].PID;
-     for (int i=0; i<c.SPIDs.Count(); i++) ss << ',' << c.SPIDs[i].PID;
-     if (c.TPID > 0)                       ss << ',' << c.TPID;
-     ss << "</location>" << std::endl;
+     if (c.Source == "A" && !satip) {
+        ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
+        indent++;
 
-     ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
-     indent++;
+        if (c.LCN_minor == -1) {
+           ss << INDENT << "<vlc:id>" << TitleNumber  << "</vlc:id>" << std::endl;
+           }
+        else {
+           ss << INDENT << "<vlc:id>" << TitleNumber  << "." << c.LCN_minor << "</vlc:id>" << std::endl;
+           }
 
-     ss << INDENT << "<vlc:id>" << TitleNumber;
-     if (c.Source == "A" and c.LCN_minor != -1)
-        ss << "." << c.LCN_minor;
-     ss << "</vlc:id>" << std::endl;
+        if (c.LCN != -1)
+           ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
+        if (c.LCN != -1 && c.LCN_minor != -1)
+           ss << INDENT << "<vlc:option>" << "logical-channel-number-minor=" << c.LCN_minor << "</vlc:option>" << std::endl;
 
-     if (c.LCN != -1) {
-         ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
-         if (c.Source == "A" and c.LCN_minor != -1)
-            ss << INDENT << "<vlc:option>" << "logical-channel-number-minor=" << c.LCN_minor << "</vlc:option>" << std::endl;
-         }
+        ss << INDENT << "<vlc:option>" << "dvb-ts-id=" << c.TID << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "program="   << c.SID << "</vlc:option>" << std::endl;
+
+        if (c.Modulation != 999) {
+           ss << INDENT << "<vlc:option>dvb-modulation=";
+
+           if      (c.Modulation == 10)  ss << "8VSB";
+           else if (c.Modulation == 11)  ss << "16VSB";
+           else if (c.Modulation == 64)  ss << "64QAM"; // may be unused at all.
+           else if (c.Modulation == 256) ss << "256QAM";
+           else                          ss << "AUTO";
+
+           ss << "</vlc:option>" << std::endl;
+           }
+        }
+     if (c.Source == "C" && !satip) {
+        ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
+        indent++;
+
+        if (c.LCN != -1)
+           ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
+
+        ss << INDENT << "<vlc:id>"     << TitleNumber  << "</vlc:id>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-ts-id=" << c.TID             << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "program="   << c.SID             << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-srate=" << c.Symbolrate*1000 << "</vlc:option>" << std::endl;
+
+        if (c.Modulation != 999) {
+           ss << INDENT << "<vlc:option>" << "dvb-modulation=";
+
+           if      (c.Modulation == 32)  ss << "32QAM";
+           else if (c.Modulation == 64)  ss << "64QAM";
+           else if (c.Modulation == 128) ss << "128QAM";
+           else if (c.Modulation == 256) ss << "256QAM";
+           else                          ss << "AUTO";
+
+           ss << "</vlc:option>" << std::endl;
+           }
+
+        if (c.Inversion != 999)
+           ss << INDENT << "<vlc:option>" << "dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
+        }
+     if (c.Source == "T" && !satip) {
+        ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
+        indent++;
+
+        if (c.LCN != -1)
+           ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
+
+        int bw = c.Bandwidth;
+        while(bw > 999) bw = round(bw/1000.0);
+
+        ss << INDENT << "<vlc:id>"     << TitleNumber      << "</vlc:id>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-ts-id="     << c.TID << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "program="       << c.SID << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-bandwidth=" << bw    << "</vlc:option>" << std::endl;
+
+        if (c.Inversion != 999)
+           ss << INDENT << "<vlc:option>" << "dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
+
+        if (c.FEC != 999) {
+           ss << INDENT << "<vlc:option>dvb-code-rate-hp=";
+
+           if      (c.FEC == 12)         ss << "1/2";
+           else if (c.FEC == 23)         ss << "2/3";
+           else if (c.FEC == 34)         ss << "3/4";
+           else if (c.FEC == 45)         ss << "4/5";
+           else if (c.FEC == 56)         ss << "5/6";
+           else if (c.FEC == 67)         ss << "6/7";
+           else if (c.FEC == 78)         ss << "7/8";
+           else if (c.FEC == 35)         ss << "3/5";
+           else if (c.FEC == 89)         ss << "8/9";
+           else if (c.FEC == 910)        ss << "9/10";
+           else if (c.FEC == 25)         ss << "2/5";
+           else if (c.FEC == 14)         ss << "1/4";
+           else if (c.FEC == 13)         ss << "1/3";
+           else                          ss << "-1";
+
+           ss << "</vlc:option>" << std::endl;
+           }
+        if (c.Modulation != 999) {
+           ss << INDENT << "<vlc:option>" << "dvb-modulation=";
+
+           if      (c.Modulation == 2)   ss << "QPSK";
+           else if (c.Modulation == 16)  ss << "16QAM";
+           else if (c.Modulation == 64)  ss << "64QAM";
+           else if (c.Modulation == 256) ss << "256QAM";
+           else                          ss << "AUTO";
+
+           ss << "</vlc:option>" << std::endl;
+           }
+
+        if (c.Transmission != 999)
+           ss << INDENT << "<vlc:option>" << "dvb-transmission=" << c.Transmission << "</vlc:option>" << std::endl;
+
+        if (c.Guard != 999) {
+           ss << INDENT << "<vlc:option>" << "dvb-guard=";
+
+           if      (c.Guard == 4)        ss << "1/4";
+           else if (c.Guard == 8)        ss << "1/8";
+           else if (c.Guard == 16)       ss << "1/16";
+           else if (c.Guard == 32)       ss << "1/32";
+           else if (c.Guard == 128)      ss << "1/128";
+           else if (c.Guard == 19128)    ss << "19/128";
+           else if (c.Guard == 19256)    ss << "19/256";
+           else                          ss << "AUTO";
+
+           ss << "</vlc:option>" << std::endl;
+           }
+
+        if (c.DelSys == 1) {
+           if (c.StreamId  != 999)
+              ss << INDENT << "<vlc:option>" << "dvb-plp-id=" << c.StreamId << "</vlc:option>" << std::endl;
+           }
+        }
+     if ((c.Source.find('S') == 0) && !satip) {
+        ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
+        indent++;
+
+        if (c.LCN != -1)
+           ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
+
+        ss << INDENT << "<vlc:id>"     << TitleNumber         << "</vlc:id>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-ts-id="        << c.TID             << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "program="          << c.SID             << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-polarization=" << c.Polarization    << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-srate="        << c.Symbolrate*1000 << "</vlc:option>" << std::endl;
+
+        if (c.Inversion != 999)
+           ss << INDENT << "<vlc:option>dvb-inversion=" << c.Inversion << "</vlc:option>" << std::endl;
+
+        if (c.FEC != 999) {
+           ss << INDENT << "<vlc:option>dvb-fec=";
+
+           if      (c.FEC == 12)        ss << "1/2";
+           else if (c.FEC == 23)        ss << "2/3";
+           else if (c.FEC == 34)        ss << "3/4";
+           else if (c.FEC == 45)        ss << "4/5";
+           else if (c.FEC == 56)        ss << "5/6";
+           else if (c.FEC == 67)        ss << "6/7";
+           else if (c.FEC == 78)        ss << "7/8";
+           else if (c.FEC == 89)        ss << "8/9";
+           else if (c.FEC == 35)        ss << "3/5";
+           else if (c.FEC == 910)       ss << "9/10";
+           else if (c.FEC == 25)        ss << "2/5";
+           else if (c.FEC == 14)        ss << "1/4";
+           else if (c.FEC == 13)        ss << "1/3";
+           else                         ss << "-1";
+
+           ss << "</vlc:option>" << std::endl;
+           }
+
+        if (c.DelSys == 1) {
+           if (c.StreamId  != 999)
+              ss << INDENT << "<vlc:option>" << "dvb-plp-id=" << c.StreamId << "</vlc:option>" << std::endl;
+
+           ss << INDENT << "<vlc:option>" << "dvb-modulation=";
+
+           if      (c.Modulation == 2)  ss << "QPSK";
+           else if (c.Modulation == 5)  ss << "8PSK";
+           else if (c.Modulation == 6)  ss << "16APSK";
+           else if (c.Modulation == 7)  ss << "32APSK";
+           else if (c.Modulation == 12) ss << "DQPSK";
+           else                         ss << "AUTO";
+
+           ss << "</vlc:option>" << std::endl;
+
+           ss << INDENT << "<vlc:option>" << "dvb-rolloff=";
+
+           if      (c.Rolloff == 20)    ss << 20;
+           else if (c.Rolloff == 25)    ss << 25;
+           else                         ss << 35;
+
+           ss << "</vlc:option>" << std::endl;
+           }
+
+        int h,l,s;
+        GetLnb(l, h, s);
+        ss << INDENT << "<vlc:option>" << "dvb-lnb-low="    << l << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-lnb-high="   << h << "</vlc:option>" << std::endl;
+        ss << INDENT << "<vlc:option>" << "dvb-lnb-switch=" << s << "</vlc:option>" << std::endl;
+
+        if (DiseqcSwitchPosition() != -1)
+           ss << INDENT << "<vlc:option>" << "dvb-satno=" << DiseqcSwitchPosition() << "</vlc:option>" << std::endl;
+        }
+
+     if (satip) {
+        ss << INDENT << "<extension application=" << '"' << AppUrl << '"' << ">" << std::endl;
+        indent++;
+
+        if (c.Source == "A" and c.LCN_minor != -1) {
+           ss << INDENT << "<vlc:id>" << TitleNumber  << "." << c.LCN_minor << "</vlc:id>" << std::endl;
+           }
+        else {
+           ss << INDENT << "<vlc:id>" << TitleNumber  << "</vlc:id>" << std::endl;
+           }
+
+        if (c.LCN != -1) {
+            ss << INDENT << "<vlc:option>" << "logical-channel-number=" << c.LCN << "</vlc:option>" << std::endl;
+            if (c.Source == "A" and c.LCN_minor != -1)
+                ss << INDENT << "<vlc:option>" << "logical-channel-number-minor=" << c.LCN_minor << "</vlc:option>" << std::endl;
+            }
+        }
 
      indent--;
      ss << INDENT << "</extension>" << std::endl;
-
      indent--;
      ss << INDENT << "</track>" << std::endl;
+
      TitleNumber++;
      } // end for()
 
@@ -1234,6 +1190,14 @@ void PrintVLCsatip(std::vector<TChannel>& List) {
   ss << INDENT << "</playlist>" << std::endl;
 
   OutputLine(ss.str());
+}
+
+void PrintVLC(std::vector<TChannel>& List) {
+  PrintVLCcommon(List, false);
+}
+
+void PrintVLCsatip(std::vector<TChannel>& List) {
+  PrintVLCcommon(List, true);
 }
 
 

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -752,14 +752,17 @@ void XmlString(std::string& s) {
 void PrintVLC(std::vector<TChannel>& List, bool satip) {
   std::stringstream ss;
   size_t indent = 0;
+
   auto t = time(nullptr);
   auto tm = localtime(&t);
-  auto year  = IntToStr(1900 + tm->tm_year, 4, false, '0');
-  auto month = IntToStr(1    + tm->tm_mon , 2, false, '0');
-  auto day   = IntToStr(0    + tm->tm_mday, 2, false, '0');
-  auto hour  = IntToStr(0    + tm->tm_hour, 2, false, '0');
-  auto min   = IntToStr(0    + tm->tm_min , 2, false, '0');
-  auto sec   = IntToStr(0    + tm->tm_sec , 2, false, '0');
+  std::stringstream date; // "yyyy.mm.ddTHH:MM:SS"
+  date <<        IntToStr(1900 + tm->tm_year, 4, false, '0');
+  date << "-" << IntToStr(1    + tm->tm_mon , 2, false, '0');
+  date << "-" << IntToStr(0    + tm->tm_mday, 2, false, '0');
+  date << "T" << IntToStr(0    + tm->tm_hour, 2, false, '0');
+  date << ":" << IntToStr(0    + tm->tm_min , 2, false, '0');
+  date << ":" << IntToStr(0    + tm->tm_sec , 2, false, '0');
+
   int src = 1;
   cSource* source = Sources.First();
   if (source and source->Description())
@@ -781,7 +784,7 @@ void PrintVLC(std::vector<TChannel>& List, bool satip) {
 
   ss << INDENT << "<title>DVB Playlist</title>" << std::endl;
   ss << INDENT << "<creator>w_scan_cpp</creator>" << std::endl;
-  ss << INDENT << "<date>" + year + "-" + month + "-" + day + "T" + hour + ":" + min + ":" + sec + "</date>" << std::endl;
+  ss << INDENT << "<date>" << date.str() << "</date>" << std::endl;
   ss << INDENT << "<info>https://gen2vdr.de/wirbel/w_scan_cpp/index2.html</info>" << std::endl;
   ss << INDENT << "<trackList>" << std::endl;
   indent++;

--- a/OutputFormats.cpp
+++ b/OutputFormats.cpp
@@ -749,7 +749,7 @@ void XmlString(std::string& s) {
   ReplaceAll(s, "\"", "&quot;");
 }
 
-void PrintVLCcommon(std::vector<TChannel>& List, bool satip) {
+void PrintVLC(std::vector<TChannel>& List, bool satip) {
   std::stringstream ss;
   size_t indent = 0;
   auto t = time(nullptr);
@@ -1190,14 +1190,6 @@ void PrintVLCcommon(std::vector<TChannel>& List, bool satip) {
   ss << INDENT << "</playlist>" << std::endl;
 
   OutputLine(ss.str());
-}
-
-void PrintVLC(std::vector<TChannel>& List) {
-  PrintVLCcommon(List, false);
-}
-
-void PrintVLCsatip(std::vector<TChannel>& List) {
-  PrintVLCcommon(List, true);
 }
 
 

--- a/OutputFormats.h
+++ b/OutputFormats.h
@@ -8,8 +8,7 @@
 #include "Helpers.h"
 
 void PrintVDR(std::vector<TChannel>& List);
-void PrintVLC(std::vector<TChannel>& List);
-void PrintVLCsatip(std::vector<TChannel>& List);
+void PrintVLC(std::vector<TChannel>& List, bool satip = false);
 void PrintXine(std::vector<TChannel>& List, bool mplayer = false);
 void PrintInitial(std::vector<TChannel>& List);
 void PrintXML(std::vector<TChannel>& List);

--- a/main.cpp
+++ b/main.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
      if      (OutputFormat == "VDR")            PrintVDR(data);
      else if (OutputFormat == "INI")            PrintIni(data);
      else if (OutputFormat == "VLC")            PrintVLC(data);
-     else if (OutputFormat == "VLC_SAT>IP")     PrintVLCsatip(data);
+     else if (OutputFormat == "VLC_SAT>IP")     PrintVLC(data, true);
      else if (OutputFormat == "XINE")           PrintXine(data);
      else if (OutputFormat == "MPLAYER")        PrintXine(data, true);
      else if (OutputFormat == "INITIAL")        PrintInitial(data);


### PR DESCRIPTION
This patch is a refactoring of the two VLC outputs (regular and SAT>IP). It combines the two formats into one. The reason for that is that the two outputs are in fact the same format (XSPF), and the differencies are small. This improves future maintainability.

Changes are:
- Join the two outputs with minimal changes (all in one source file).
- Add date-time at the start of the output file (missing until now, and very useful).
- More tabulated code for better understanding.
- Other very small modifications.

